### PR TITLE
In case the projects name is used as the module name any dashes in th…

### DIFF
--- a/plugin/src/main/groovy/org/gradle/plugins/nbm/NbmPluginExtension.java
+++ b/plugin/src/main/groovy/org/gradle/plugins/nbm/NbmPluginExtension.java
@@ -100,7 +100,7 @@ public final class NbmPluginExtension {
 
     public String getModuleName() {
         if (moduleName == null) {
-            return project.getName();
+            return project.getName().replace('-', '.');
         }
         return moduleName;
     }

--- a/plugin/src/test/groovy/org/gradle/plugins/nbm/NbmPluginTest.groovy
+++ b/plugin/src/test/groovy/org/gradle/plugins/nbm/NbmPluginTest.groovy
@@ -81,11 +81,11 @@ public class NbmPluginTest {
     }
 
     @Test
-    public void 'default module name is the project name.'() {
+    public void 'default module name is the project name with dots instead of dashes.'() {
         Project project = ProjectBuilder.builder().withName('my-test-project').build()
         project.project.plugins.apply(NbmPlugin)
 
-        assertEquals(project.nbm.moduleName, 'my-test-project')
+        assertEquals(project.nbm.moduleName, 'my.test.project')
     }
 
     @Test


### PR DESCRIPTION
…e projects name are replaced by dots to be compliant with naming conventions for the code name base.

Fixes radimk/gradle-nbm-plugin#6