### PR TITLE
Improving cooperation with NetBeans

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-.nb-gradle
+.nb-gradle/
+.nb-gradle-properties
 *.class
 .gradle
 build

--- a/plugin/src/main/groovy/org/gradle/plugins/nbm/NbmPlugin.groovy
+++ b/plugin/src/main/groovy/org/gradle/plugins/nbm/NbmPlugin.groovy
@@ -92,7 +92,7 @@ public class NbmPlugin implements Plugin<Project> {
             dependsOn 'netbeans'
 
             Path buildPath = project.buildDir.toPath()
-            Path testUserDir = buildPath.resolve('testuserdir')
+            Path testUserDir = buildPath.resolve(NetBeansTask.TEST_USER_DIR_NAME)
             if (project.hasProperty('netBeansExecutable')) {
                 doFirst {
                     def confFile = testUserDir.resolve('etc').resolve('netbeans.conf')

--- a/plugin/src/main/groovy/org/gradle/plugins/nbm/NbmPlugin.groovy
+++ b/plugin/src/main/groovy/org/gradle/plugins/nbm/NbmPlugin.groovy
@@ -105,7 +105,16 @@ public class NbmPlugin implements Plugin<Project> {
                 List args = new LinkedList()
                 args.addAll([ project.netBeansExecutable, '--userdir', testUserDir])
 
-                if (debug) {
+                String debuggerPort = null;
+                if (project.hasProperty('debuggerJpdaPort')) {
+                    debuggerPort = project.debuggerJpdaPort
+                }
+
+                if (debuggerPort != null) {
+                    args.add('-J-Xdebug')
+                    args.add("-J-Xrunjdwp:transport=dt_socket,server=n,address=${debuggerPort}")
+                }
+                else if (debug) {
                     def nbmDebugPort = '5006'
                     if (project.hasProperty(nbmDebugPort)) {
                         nbmDebugPort = project.nbmDebugPort.trim()

--- a/plugin/src/main/groovy/org/gradle/plugins/nbm/NetBeansTask.groovy
+++ b/plugin/src/main/groovy/org/gradle/plugins/nbm/NetBeansTask.groovy
@@ -12,6 +12,7 @@ import java.util.jar.Attributes
 import java.util.jar.JarFile
 
 class NetBeansTask extends ConventionTask {
+    public static final String TEST_USER_DIR_NAME = 'testuserdir'
 
     private FileCollection classpath
 
@@ -21,7 +22,7 @@ class NetBeansTask extends ConventionTask {
     private NbmPluginExtension netbeansExt() {
         project.extensions.nbm
     }
-    
+
     @Input
     File getInputModuleJarFile() {
         project.tasks.jar.archivePath
@@ -51,6 +52,14 @@ class NetBeansTask extends ConventionTask {
         this.classpath = project.files(oldClasspath ?: [], classpath)
     }
 
+    private File getCacheDir() {
+        File result = project.buildDir
+        result = new File(result, TEST_USER_DIR_NAME)
+        result = new File(result, 'var')
+        result = new File(result, 'cache')
+        return result
+    }
+
     @TaskAction
     void generate() {
         project.logger.info "NetBeansTask running"
@@ -68,6 +77,8 @@ class NetBeansTask extends ConventionTask {
         // TODO handle eager/autoload
         def modulesDir = new File(moduleDir, 'modules')
         def modulesExtDir = new File(modulesDir, 'ext')
+
+        project.delete(getCacheDir())
 
         def moduleJarName = netbeansExt().moduleName.replace('.', '-') + '.jar'
         project.copy { CopySpec it ->


### PR DESCRIPTION
- Users of this plugin are now able to use the debugging mode when the debugee attaches to NB
- Deleting the cache folder in "testuserdir" before starting NB because otherwise the started NB might still use the old version of the built plugin.

ps.: Can you release a new version after these changes? Because I wish to finally move my Gradle plugin to use this plugin, so I will no longer need to have a duplicate of your plugin in my *buildSrc*.