### PR TITLE
Custom manifests configuration in the build script

### DIFF
--- a/plugin/src/integTest/groovy/org/gradle/plugins/nbm/integtest/ManifestGenerationTest.groovy
+++ b/plugin/src/integTest/groovy/org/gradle/plugins/nbm/integtest/ManifestGenerationTest.groovy
@@ -83,4 +83,32 @@ nbm {
         assert manifest.get('Created-By') == 'Gradle NBM plugin'
         manifest
     }
+
+    def "manifest file with custom manifest entries"() {
+        // Set the moduleName because I have no idea what the project's name is,
+        // so can't rely on the default value for that
+        buildFile << """
+apply plugin: org.gradle.plugins.nbm.NbmPlugin
+version = '3.5.6'
+nbm {
+  String lazyValue = null
+  customManifest {
+    entry 'myTestKey', 'myTestValue'
+    entry 'myLazyKey', { lazyValue }
+  }
+
+  lazyValue = 'myLazyValue'
+
+  moduleName = 'my-test-project'
+  implementationVersion = version
+}
+"""
+        when:
+        GradleProject project = runTasks(integTestDir, "generateModuleManifest")
+
+        then:
+        def manifest = checkDefaultModuleManifest(project)
+        assert manifest.get('myTestKey') == 'myTestValue'
+        assert manifest.get('myLazyKey') == 'myLazyValue'
+    }
 }

--- a/plugin/src/main/groovy/org/gradle/plugins/nbm/CustomManifestEntries.java
+++ b/plugin/src/main/groovy/org/gradle/plugins/nbm/CustomManifestEntries.java
@@ -1,0 +1,24 @@
+package org.gradle.plugins.nbm;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public final class CustomManifestEntries {
+    private final Map<String, Object> entries;
+
+    public CustomManifestEntries() {
+        this.entries = new HashMap<>();
+    }
+
+    public void entry(String key, Object value) {
+        entries.put(key, value);
+    }
+
+    public void entries(Map<String, ?> newEntries) {
+        entries.putAll(newEntries);
+    }
+
+    public Map<String, Object> getEntries() {
+        return entries;
+    }
+}

--- a/plugin/src/main/groovy/org/gradle/plugins/nbm/ModuleManifestTask.groovy
+++ b/plugin/src/main/groovy/org/gradle/plugins/nbm/ModuleManifestTask.groovy
@@ -150,6 +150,10 @@ class ModuleManifestTask extends ConventionTask {
             result.put('OpenIDE-Module-Install', moduleInstall.replace('.', '/') + '.class')
         }
 
+        netbeansExt().customManifest.entries.each { key, value ->
+            result.put(key, EvaluateUtils.asString(value))
+        }
+
         return result
     }
 

--- a/plugin/src/main/groovy/org/gradle/plugins/nbm/NbmPluginExtension.java
+++ b/plugin/src/main/groovy/org/gradle/plugins/nbm/NbmPluginExtension.java
@@ -1,6 +1,7 @@
 package org.gradle.plugins.nbm;
 
 import groovy.lang.Closure;
+import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 
@@ -21,6 +22,7 @@ public final class NbmPluginExtension {
     private String localizingBundle;
     private String moduleInstall;
     private final NbmFriendPackages friendPackages;
+    private final CustomManifestEntries customManifest;
 
     private final Configuration harnessConfiguration;
 
@@ -41,6 +43,7 @@ public final class NbmPluginExtension {
         this.friendPackages = new NbmFriendPackages();
         this.keyStore = new NbmKeyStoreDef();
         this.requires = new LinkedList<>();
+        this.customManifest = new CustomManifestEntries();
         this.project = project;
     }
 
@@ -48,10 +51,26 @@ public final class NbmPluginExtension {
         return friendPackages;
     }
 
-    public void friendPackages(Closure<?> configBlock) {
+    private static void configWith(Object arg, Closure<?> configBlock) {
         configBlock.setResolveStrategy(Closure.DELEGATE_FIRST);
-        configBlock.setDelegate(friendPackages);
-        configBlock.call(friendPackages);
+        configBlock.setDelegate(arg);
+        configBlock.call(arg);
+    }
+
+    public void friendPackages(Closure<?> configBlock) {
+        configWith(friendPackages, configBlock);
+    }
+
+    public CustomManifestEntries getCustomManifest() {
+        return customManifest;
+    }
+
+    public void customManifest(Action<? super CustomManifestEntries> configuration) {
+        configuration.execute(customManifest);
+    }
+
+    public void customManifest(Closure<?> configBlock) {
+        configWith(customManifest, configBlock);
     }
 
     public Configuration getHarnessConfiguration() {

--- a/plugin/src/main/groovy/org/gradle/plugins/nbm/NbmPluginExtension.java
+++ b/plugin/src/main/groovy/org/gradle/plugins/nbm/NbmPluginExtension.java
@@ -48,7 +48,7 @@ public final class NbmPluginExtension {
         return friendPackages;
     }
 
-    public void friendPackages(Closure<NbmFriendPackages> configBlock) {
+    public void friendPackages(Closure<?> configBlock) {
         configBlock.setResolveStrategy(Closure.DELEGATE_FIRST);
         configBlock.setDelegate(friendPackages);
         configBlock.call(friendPackages);


### PR DESCRIPTION
This patch provides the user the ability to configure manifest entries in the build script. This is benefical when you want to add manifest entries based on the properties of the build (i.e., they do not have a constant value).