### PR TITLE
Add cluster handling.

### DIFF
--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -58,6 +58,7 @@ dependencies {
   testCompile "junit:junit:4.11"
   testCompile "org.hamcrest:hamcrest-library:1.3"
   testCompile "com.google.guava:guava:14.0.1"
+  testCompile group: 'xml-resolver', name: 'xml-resolver', version: '1.2'
 }
 repositories {
     mavenCentral()
@@ -75,6 +76,8 @@ sourceSets {
     }
 }
 
+def catalogPath = file('src/integTest/resources/catalog.xml').canonicalPath
+
 task integTest(type: Test) {
     description = 'Runs the integration tests.'
     group = 'verification'
@@ -84,6 +87,9 @@ task integTest(type: Test) {
     reports.html.destination = file("${project.reporting.baseDir}/$name")
 
     shouldRunAfter test
+
+	systemProperty "xml.catalog.files", catalogPath
+
 }
 
 task testJenkins(dependsOn: test) {
@@ -141,4 +147,8 @@ bintray {
 
 idea.module {
     testSourceDirs += file('src/integTest/groovy')
+}
+
+test {
+	systemProperty "xml.catalog.files", file('src/integTest/resources/catalog.xml')
 }

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -88,7 +88,7 @@ task integTest(type: Test) {
 
     shouldRunAfter test
 
-	systemProperty "xml.catalog.files", catalogPath
+    systemProperty "xml.catalog.files", catalogPath
 
 }
 

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -148,7 +148,3 @@ bintray {
 idea.module {
     testSourceDirs += file('src/integTest/groovy')
 }
-
-test {
-	systemProperty "xml.catalog.files", file('src/integTest/resources/catalog.xml')
-}

--- a/plugin/src/integTest/groovy/org/gradle/plugins/nbm/integtest/AbstractIntegrationTest.groovy
+++ b/plugin/src/integTest/groovy/org/gradle/plugins/nbm/integtest/AbstractIntegrationTest.groovy
@@ -33,7 +33,7 @@ abstract class AbstractIntegrationTest extends Specification {
     File integTestDir
     File buildFile
     File gradlePropsFile
-	CatalogManager cm 
+    CatalogManager cm 
 	
     def setup() {
         integTestDir = new File('build/integTest')
@@ -69,9 +69,9 @@ repositories {
         settingsFile << ''
 
         gradlePropsFile = createNewFile(integTestDir, 'gradle.properties')
-		
-		cm = new CatalogManager()
-		cm.setVerbosity(9)
+        
+        cm = new CatalogManager()
+        cm.setVerbosity(9)
     }
 
     protected File createNewDir(File parent, String dirname) {

--- a/plugin/src/integTest/groovy/org/gradle/plugins/nbm/integtest/AbstractIntegrationTest.groovy
+++ b/plugin/src/integTest/groovy/org/gradle/plugins/nbm/integtest/AbstractIntegrationTest.groovy
@@ -22,6 +22,7 @@ import org.gradle.tooling.model.GradleProject
 import spock.lang.Specification
 
 import static org.spockframework.util.Assert.fail
+import org.apache.xml.resolver.CatalogManager
 
 /**
  * Abstract integration test using Gradle's tooling API.
@@ -32,7 +33,8 @@ abstract class AbstractIntegrationTest extends Specification {
     File integTestDir
     File buildFile
     File gradlePropsFile
-
+	CatalogManager cm 
+	
     def setup() {
         integTestDir = new File('build/integTest')
 
@@ -67,6 +69,9 @@ repositories {
         settingsFile << ''
 
         gradlePropsFile = createNewFile(integTestDir, 'gradle.properties')
+		
+		cm = new CatalogManager()
+		cm.setVerbosity(9)
     }
 
     protected File createNewDir(File parent, String dirname) {

--- a/plugin/src/integTest/groovy/org/gradle/plugins/nbm/integtest/FileMatchers.java
+++ b/plugin/src/integTest/groovy/org/gradle/plugins/nbm/integtest/FileMatchers.java
@@ -12,11 +12,13 @@ public class FileMatchers {
         return new TypeSafeMatcher<File>() {
             File fileTested;
 
+			@Override
             public boolean matchesSafely(File item) {
                 fileTested = item;
                 return item.exists();
             }
 
+			@Override
             public void describeTo(Description description) {
                 description.appendText(" that file ");
                 description.appendValue(fileTested);
@@ -29,11 +31,13 @@ public class FileMatchers {
         return new TypeSafeMatcher<File>() {
             File fileTested;
 
+			@Override
             public boolean matchesSafely(File item) {
                 fileTested = item;
                 return item.isFile();
             }
 
+			@Override
             public void describeTo(Description description) {
                 description.appendText(" that ");
                 description.appendValue(fileTested);
@@ -41,4 +45,7 @@ public class FileMatchers {
             }
         };
     }
+
+	private FileMatchers() {
+	}
 }

--- a/plugin/src/integTest/groovy/org/gradle/plugins/nbm/integtest/FileMatchers.java
+++ b/plugin/src/integTest/groovy/org/gradle/plugins/nbm/integtest/FileMatchers.java
@@ -12,13 +12,13 @@ public class FileMatchers {
         return new TypeSafeMatcher<File>() {
             File fileTested;
 
-			@Override
+            @Override
             public boolean matchesSafely(File item) {
                 fileTested = item;
                 return item.exists();
             }
 
-			@Override
+            @Override
             public void describeTo(Description description) {
                 description.appendText(" that file ");
                 description.appendValue(fileTested);
@@ -31,13 +31,13 @@ public class FileMatchers {
         return new TypeSafeMatcher<File>() {
             File fileTested;
 
-			@Override
+            @Override
             public boolean matchesSafely(File item) {
                 fileTested = item;
                 return item.isFile();
             }
 
-			@Override
+            @Override
             public void describeTo(Description description) {
                 description.appendText(" that ");
                 description.appendValue(fileTested);
@@ -46,6 +46,6 @@ public class FileMatchers {
         };
     }
 
-	private FileMatchers() {
-	}
+    private FileMatchers() {
+    }
 }

--- a/plugin/src/integTest/groovy/org/gradle/plugins/nbm/integtest/StandaloneNbmProjectTest.groovy
+++ b/plugin/src/integTest/groovy/org/gradle/plugins/nbm/integtest/StandaloneNbmProjectTest.groovy
@@ -209,7 +209,7 @@ public class Service {
         Iterables.contains(moduleClasspath(moduleJar), 'ext/slf4j-api-1.7.2.jar')
     }
 
-	def "build with no cluster defined"() {
+    def "build with no cluster defined"() {
         buildFile << """
 apply plugin: 'java'
 apply plugin: org.gradle.plugins.nbm.NbmPlugin
@@ -220,7 +220,7 @@ nbm {
 """
         when:
         GradleProject project = runTasks(integTestDir, "nbm")
-		File module = new File(getIntegTestDir(), 'build/nbm/com-foo-acme.nbm')
+        File module = new File(getIntegTestDir(), 'build/nbm/com-foo-acme.nbm')
 		
         then:
         // TODO expect output file with all required entries
@@ -230,10 +230,10 @@ nbm {
         assertThat(new File(getIntegTestDir(), 'build/module/modules/com-foo-acme.jar'), FileMatchers.exists())
         assertThat(new File(getIntegTestDir(), 'build/module/update_tracking/com-foo-acme.xml'), FileMatchers.exists())	
         assertThat(module, FileMatchers.exists())
-		moduleXml(module, 'Info/info.xml').getProperty('@targetcluster').text().isEmpty()
-	}
+        moduleXml(module, 'Info/info.xml').getProperty('@targetcluster').text().isEmpty()
+    }
 	
-	def "build with cluster defined that is not called 'extra'"() {
+    def "build with cluster defined that is not called 'extra'"() {
         buildFile << """
 apply plugin: 'java'
 apply plugin: org.gradle.plugins.nbm.NbmPlugin
@@ -245,7 +245,7 @@ nbm {
 """
         when:
         GradleProject project = runTasks(integTestDir, "nbm")
-		File module = new File(getIntegTestDir(), 'build/nbm/com-foo-acme.nbm')
+        File module = new File(getIntegTestDir(), 'build/nbm/com-foo-acme.nbm')
 		
         then:
         // TODO expect output file with all required entries
@@ -255,10 +255,10 @@ nbm {
         assertThat(new File(getIntegTestDir(), 'build/module/modules/com-foo-acme.jar'), FileMatchers.exists())
         assertThat(new File(getIntegTestDir(), 'build/module/update_tracking/com-foo-acme.xml'), FileMatchers.exists())	
         assertThat(module, FileMatchers.exists())
-		moduleXml(module, 'Info/info.xml').getProperty('@targetcluster').text() == "myCluster"
-	}
+        moduleXml(module, 'Info/info.xml').getProperty('@targetcluster').text() == "myCluster"
+    }
 	
-	def "build with cluster defined that is called 'extra'"() {
+    def "build with cluster defined that is called 'extra'"() {
         buildFile << """
 apply plugin: 'java'
 apply plugin: org.gradle.plugins.nbm.NbmPlugin
@@ -270,7 +270,7 @@ nbm {
 """
         when:
         GradleProject project = runTasks(integTestDir, "nbm")
-		File module = new File(getIntegTestDir(), 'build/nbm/com-foo-acme.nbm')
+        File module = new File(getIntegTestDir(), 'build/nbm/com-foo-acme.nbm')
 		
         then:
         // TODO expect output file with all required entries
@@ -280,8 +280,8 @@ nbm {
         assertThat(new File(getIntegTestDir(), 'build/module/modules/com-foo-acme.jar'), FileMatchers.exists())
         assertThat(new File(getIntegTestDir(), 'build/module/update_tracking/com-foo-acme.xml'), FileMatchers.exists())	
         assertThat(module, FileMatchers.exists())
-		moduleXml(module, 'Info/info.xml').getProperty('@targetcluster').text().isEmpty()
-	}
+        moduleXml(module, 'Info/info.xml').getProperty('@targetcluster').text().isEmpty()
+    }
 	
     private Iterable<String> moduleDependencies(File jarFile) {
         JarFile jar = new JarFile(jarFile)
@@ -309,13 +309,11 @@ nbm {
         props
     }
 	
-
-	
-	private GPathResult moduleXml(File jarFile, String resourceName) {
-		new JarFile(jarFile).withCloseable { jar ->
-			jar.getInputStream(jar.getEntry(resourceName)).withCloseable { is ->
-				return new XmlSlurper(new ResolvingXMLReader(cm)).parse(is)
-			}
-		}
-	}
+    private GPathResult moduleXml(File jarFile, String resourceName) {
+        new JarFile(jarFile).withCloseable { jar ->
+            jar.getInputStream(jar.getEntry(resourceName)).withCloseable { is ->
+                return new XmlSlurper(new ResolvingXMLReader(cm)).parse(is)
+            }
+        }
+    }
 }

--- a/plugin/src/integTest/resources/autoupdate-info-2_4.dtd
+++ b/plugin/src/integTest/resources/autoupdate-info-2_4.dtd
@@ -1,0 +1,55 @@
+<!-- -//NetBeans//DTD Autoupdate Module Info 2.4//EN -->
+<!-- XML representation of Autoupdate Module Info file -->
+<!-- (Info.xml is included in NBM archive) -->
+
+<!ELEMENT module (description?, module_notification?, external_package*, (manifest | l10n), license?)>
+<!ATTLIST module codenamebase CDATA #REQUIRED
+                 homepage     CDATA #IMPLIED
+                 distribution CDATA #IMPLIED
+                 license      CDATA #IMPLIED
+                 downloadsize CDATA #IMPLIED
+                 needsrestart CDATA #IMPLIED
+                 moduleauthor CDATA #IMPLIED
+                 releasedate  CDATA #IMPLIED
+                 global       CDATA #IMPLIED
+                 targetcluster CDATA #IMPLIED>
+
+<!ELEMENT description (#PCDATA)>
+
+<!ELEMENT module_notification (#PCDATA)>
+
+<!ELEMENT external_package EMPTY>
+<!ATTLIST external_package
+                 name CDATA #REQUIRED
+                 target_name  CDATA #REQUIRED
+                 start_url    CDATA #REQUIRED
+                 description  CDATA #IMPLIED>
+
+<!ELEMENT manifest EMPTY>
+<!ATTLIST manifest OpenIDE-Module CDATA #REQUIRED
+                   OpenIDE-Module-Name CDATA #REQUIRED
+                   OpenIDE-Module-Specification-Version CDATA #REQUIRED
+                   OpenIDE-Module-Implementation-Version CDATA #IMPLIED
+                   OpenIDE-Module-Module-Dependencies CDATA #IMPLIED
+                   OpenIDE-Module-Package-Dependencies CDATA #IMPLIED
+                   OpenIDE-Module-Java-Dependencies CDATA #IMPLIED
+                   OpenIDE-Module-IDE-Dependencies CDATA #IMPLIED
+                   OpenIDE-Module-Short-Description CDATA #IMPLIED
+                   OpenIDE-Module-Long-Description CDATA #IMPLIED
+                   OpenIDE-Module-Display-Category CDATA #IMPLIED
+                   OpenIDE-Module-Provides CDATA #IMPLIED
+                   OpenIDE-Module-Requires CDATA #IMPLIED>
+
+<!ELEMENT l10n EMPTY>
+<!ATTLIST l10n   langcode             CDATA #IMPLIED
+                 brandingcode         CDATA #IMPLIED
+                 module_spec_version  CDATA #IMPLIED
+                 module_major_version CDATA #IMPLIED
+                 OpenIDE-Module-Name  CDATA #IMPLIED
+                 OpenIDE-Module-Long-Description CDATA #IMPLIED>
+
+<!ELEMENT license (#PCDATA)>
+<!ATTLIST license name CDATA #REQUIRED>
+
+
+

--- a/plugin/src/integTest/resources/catalog.xml
+++ b/plugin/src/integTest/resources/catalog.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+Copyright 1997-2010 Oracle and/or its affiliates. All rights reserved.
+
+Oracle and Java are registered trademarks of Oracle and/or its affiliates.
+Other names may be trademarks of their respective owners.
+
+
+The contents of this file are subject to the terms of either the GNU
+General Public License Version 2 only ("GPL") or the Common
+Development and Distribution License("CDDL") (collectively, the
+"License"). You may not use this file except in compliance with the
+License. You can obtain a copy of the License at
+http://www.netbeans.org/cddl-gplv2.html
+or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
+specific language governing permissions and limitations under the
+License.  When distributing the software, include this License Header
+Notice in each file and include the License file at
+nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
+particular file as subject to the "Classpath" exception as provided
+by Oracle in the GPL Version 2 section of the License file that
+accompanied this code. If applicable, add the following below the
+License Header, with the fields enclosed by brackets [] replaced by
+your own identifying information:
+"Portions Copyrighted [year] [name of copyright owner]"
+
+Contributor(s):
+
+    The Original Software is NetBeans. The Initial Developer of the Original
+Software is Sun Microsystems, Inc. Portions Copyright 1997-2006 Sun
+    Microsystems, Inc. All Rights Reserved.
+
+If you wish your version of this file to be governed by only the CDDL
+or only the GPL Version 2, indicate your decision by adding
+"[Contributor] elects to include this software in this distribution
+under the [CDDL or GPL Version 2] license." If you do not indicate a
+single choice of license, a recipient has the option to distribute
+your version of this file under either the CDDL, the GPL Version 2 or
+to extend the choice of license to its licensees as provided above.
+However, if you add GPL Version 2 code and therefore, elected the GPL
+Version 2 license, then the option applies only if the new code is
+made subject to such option by the copyright holder.
+-->
+<!--
+	Document   : catalog.xml
+	Created on : December 30, 2016, 7:49 PM
+	Author     : flacy
+	Description:
+		Purpose of the OASIS XML Catalog document follows.
+-->
+
+<!-- see http://www.oasis-open.org/committees/entity/spec.html -->
+<!DOCTYPE catalog PUBLIC "-//OASIS//DTD Entity Resolution XML Catalog V1.0//EN"
+         "http://www.oasis-open.org/committees/entity/release/1.0/catalog.dtd">
+
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">                
+
+	<!-- TODO fill real entries instead of sample one. -->
+	<public publicId="-//NetBeans//DTD Autoupdate Module Info 2.4//EN" uri="autoupdate-info-2_4.dtd"/>
+	<system systemId="http://www.netbeans.org/dtds/autoupdate-info-2_3.dtd" uri="autoupdate-info-2_4.dtd"/>
+    
+	<!-- For XML schemas the <uri> element is recommended 
+	to specify the resource, e.g: -->
+	<!--
+	<uri name="http://org.company/xml/schemas" uri="file:/path/schema.xsd"/>
+	-->
+        
+	<!-- If xsi:schemaLocation is specified in XML document e.g.
+	xsi:schemaLocation="http://org.company/xml/schemas http://org.company/xml/schemas/schema.xsd"
+	the <system> element can be used to specify the local resource, e.g: -->
+	<!--
+	<system systemId="http://org.company/xml/schemas/schema.xsd" uri="file:/path/schema.xsd"/>
+	-->
+</catalog>

--- a/plugin/src/integTest/resources/catalog.xml
+++ b/plugin/src/integTest/resources/catalog.xml
@@ -1,76 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-
-Copyright 1997-2010 Oracle and/or its affiliates. All rights reserved.
-
-Oracle and Java are registered trademarks of Oracle and/or its affiliates.
-Other names may be trademarks of their respective owners.
-
-
-The contents of this file are subject to the terms of either the GNU
-General Public License Version 2 only ("GPL") or the Common
-Development and Distribution License("CDDL") (collectively, the
-"License"). You may not use this file except in compliance with the
-License. You can obtain a copy of the License at
-http://www.netbeans.org/cddl-gplv2.html
-or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
-specific language governing permissions and limitations under the
-License.  When distributing the software, include this License Header
-Notice in each file and include the License file at
-nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
-particular file as subject to the "Classpath" exception as provided
-by Oracle in the GPL Version 2 section of the License file that
-accompanied this code. If applicable, add the following below the
-License Header, with the fields enclosed by brackets [] replaced by
-your own identifying information:
-"Portions Copyrighted [year] [name of copyright owner]"
-
-Contributor(s):
-
-    The Original Software is NetBeans. The Initial Developer of the Original
-Software is Sun Microsystems, Inc. Portions Copyright 1997-2006 Sun
-    Microsystems, Inc. All Rights Reserved.
-
-If you wish your version of this file to be governed by only the CDDL
-or only the GPL Version 2, indicate your decision by adding
-"[Contributor] elects to include this software in this distribution
-under the [CDDL or GPL Version 2] license." If you do not indicate a
-single choice of license, a recipient has the option to distribute
-your version of this file under either the CDDL, the GPL Version 2 or
-to extend the choice of license to its licensees as provided above.
-However, if you add GPL Version 2 code and therefore, elected the GPL
-Version 2 license, then the option applies only if the new code is
-made subject to such option by the copyright holder.
--->
-<!--
-	Document   : catalog.xml
-	Created on : December 30, 2016, 7:49 PM
-	Author     : flacy
-	Description:
-		Purpose of the OASIS XML Catalog document follows.
--->
-
-<!-- see http://www.oasis-open.org/committees/entity/spec.html -->
 <!DOCTYPE catalog PUBLIC "-//OASIS//DTD Entity Resolution XML Catalog V1.0//EN"
          "http://www.oasis-open.org/committees/entity/release/1.0/catalog.dtd">
 
 <catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">                
 
-	<!-- TODO fill real entries instead of sample one. -->
 	<public publicId="-//NetBeans//DTD Autoupdate Module Info 2.4//EN" uri="autoupdate-info-2_4.dtd"/>
 	<system systemId="http://www.netbeans.org/dtds/autoupdate-info-2_3.dtd" uri="autoupdate-info-2_4.dtd"/>
-    
-	<!-- For XML schemas the <uri> element is recommended 
-	to specify the resource, e.g: -->
-	<!--
-	<uri name="http://org.company/xml/schemas" uri="file:/path/schema.xsd"/>
-	-->
-        
-	<!-- If xsi:schemaLocation is specified in XML document e.g.
-	xsi:schemaLocation="http://org.company/xml/schemas http://org.company/xml/schemas/schema.xsd"
-	the <system> element can be used to specify the local resource, e.g: -->
-	<!--
-	<system systemId="http://org.company/xml/schemas/schema.xsd" uri="file:/path/schema.xsd"/>
-	-->
+
 </catalog>

--- a/plugin/src/main/groovy/org/gradle/plugins/nbm/NbmTask.groovy
+++ b/plugin/src/main/groovy/org/gradle/plugins/nbm/NbmTask.groovy
@@ -77,6 +77,15 @@ class NbmTask extends ConventionTask {
             signature.alias = keyStore.username
             signature.storepass = keyStore.password
         }
+		
+		// The CreateNbmMojo class tests for "extra" (the default cluster)
+		// and will not set the target cluster to that value.  We should do the
+		// same.
+		String cluster = nbm.cluster ?: "extra"
+		if (!cluster.equals("extra")) {
+			makenbm.setTargetcluster(cluster)
+		}
+		
         makenbm.execute()
     }
 


### PR DESCRIPTION
The extension class has the cluster attribute, but the makenbm task
did not have it set.  The equivalent maven mojo does not set the 
target cluster when the cluster value is "extra" (the default). Neither
does this change.