### PR TITLE
Fixes `nbm.friendPackages.addWithSubPackages`

### DIFF
--- a/plugin/src/integTest/groovy/org/gradle/plugins/nbm/integtest/AbstractIntegrationTest.groovy
+++ b/plugin/src/integTest/groovy/org/gradle/plugins/nbm/integtest/AbstractIntegrationTest.groovy
@@ -33,8 +33,8 @@ abstract class AbstractIntegrationTest extends Specification {
     File integTestDir
     File buildFile
     File gradlePropsFile
-    CatalogManager cm 
-	
+    CatalogManager cm
+
     def setup() {
         integTestDir = new File('build/integTest')
 
@@ -69,25 +69,54 @@ repositories {
         settingsFile << ''
 
         gradlePropsFile = createNewFile(integTestDir, 'gradle.properties')
-        
+
         cm = new CatalogManager()
         cm.setVerbosity(9)
     }
 
     protected File createNewDir(File parent, String dirname) {
         File dir = new File(parent, dirname)
-
-        if(!dir.exists()) {
-            if(!dir.mkdirs()) {
-                fail("Unable to create new test directory $dir.canonicalPath.")
-            }
-        }
-
+        ensureDirectory(dir)
         dir
     }
 
     protected File createNewFile(File parent, String filename) {
         File file = new File(parent, filename)
+
+        if(!file.exists()) {
+            if(!file.createNewFile()) {
+                fail("Unable to create new test file $file.canonicalPath.")
+            }
+        }
+
+        file
+    }
+
+    private static void ensureDirectory(File dir) {
+        if(!dir.exists()) {
+            if(!dir.mkdirs()) {
+                fail("Unable to create new test directory $dir.canonicalPath.")
+            }
+        }
+    }
+
+    private static File subPath(File root, String... childParts) {
+        File file = root
+        for (String part: childParts) {
+            file = new File(file, part)
+        }
+        file
+    }
+
+    protected File createProjectDir(String... pathParts) {
+        File dir = subPath(integTestDir, pathParts)
+        ensureDirectory(dir)
+        dir
+    }
+
+    protected File createProjectFile(String... pathParts) {
+        File file = subPath(integTestDir, pathParts)
+        ensureDirectory(file.parentFile)
 
         if(!file.exists()) {
             if(!file.createNewFile()) {

--- a/plugin/src/integTest/groovy/org/gradle/plugins/nbm/integtest/ManifestUtils.java
+++ b/plugin/src/integTest/groovy/org/gradle/plugins/nbm/integtest/ManifestUtils.java
@@ -7,17 +7,17 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Properties;
+import java.util.jar.Manifest;
 
 public final class ManifestUtils {
     public static Map<String, String> readManifest(Path path) throws IOException {
         try (InputStream fileInput = Files.newInputStream(path);
                 InputStream input = new BufferedInputStream(fileInput)) {
-            Properties properties = new Properties();
-            properties.load(input);
+            Manifest manifest = new Manifest(input);
+            Map<?, ?> entries = manifest.getMainAttributes();
 
-            Map<String, String> result = new HashMap<>(2 * properties.size());
-            for (Map.Entry<?, ?> entry: properties.entrySet()) {
+            Map<String, String> result = new HashMap<>(2 * entries.size());
+            for (Map.Entry<?, ?> entry: entries.entrySet()) {
                 result.put(entry.getKey().toString(), entry.getValue().toString());
             }
 

--- a/plugin/src/main/groovy/org/gradle/plugins/nbm/ModuleManifestTask.groovy
+++ b/plugin/src/main/groovy/org/gradle/plugins/nbm/ModuleManifestTask.groovy
@@ -137,7 +137,7 @@ class ModuleManifestTask extends ConventionTask {
         }
         result.put('OpenIDE-Module-Specification-Version', netbeansExt().specificationVersion)
 
-        def packageList = netbeansExt().friendPackages.packageList
+        def packageList = netbeansExt().friendPackages.packageListPattern
         if (!packageList.isEmpty()) {
             Set packageListSet = new HashSet(packageList)
             def packages = packageListSet.toArray()

--- a/plugin/src/main/groovy/org/gradle/plugins/nbm/NbmFriendPackages.java
+++ b/plugin/src/main/groovy/org/gradle/plugins/nbm/NbmFriendPackages.java
@@ -1,11 +1,13 @@
 package org.gradle.plugins.nbm;
 
+import org.gradle.api.tasks.SourceSet;
+
 import java.io.File;
+import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
 import java.util.regex.Pattern;
-import org.gradle.api.tasks.SourceSet;
 
 public final class NbmFriendPackages {
     private final List<PackageNameGenerator> packageList;
@@ -83,6 +85,22 @@ public final class NbmFriendPackages {
             currentNames.findPackages(result);
         }
         return result;
+    }
+
+    public List<String> getPackageListPattern() {
+        List<String> packages = getPackageList();
+        List<String> result = new ArrayList<>(packages.size());
+        for (String packageName: packages) {
+            result.add(toStarImport(packageName));
+        }
+        return result;
+    }
+
+    private static String toStarImport(String packageName) {
+        String suffix = ".*";
+        return packageName.endsWith(suffix)
+                ? packageName
+                : packageName + suffix;
     }
 
     private interface PackageNameGenerator {


### PR DESCRIPTION
`nbm.friendPackages.addWithSubPackages` does not work because NB expects a ".*" added after package names. This pull request fixes it.

Also, if the user does not provide the trailing `.*`, it will be added automatically.