### PR TITLE
Fix property name letter case to match the task

### DIFF
--- a/samples/standalone/build.gradle
+++ b/samples/standalone/build.gradle
@@ -50,7 +50,7 @@ dependencies {
     compile 'org.slf4j:slf4j-api:1.7.2'
 }
 
-// set netbeansInstallDir project property
+// set netBeansInstallDir project property
 
 task netBeansRun(type: Exec) {
     doFirst {


### PR DESCRIPTION
Get `netBeansInstallDir property is not specified...` too much times.

Two hours later: I understand that the B letter should be upper cased:

https://github.com/radimk/gradle-nbm-plugin/blob/80a01a347d965480cf6fbb5035ff6e85baa26d52/samples/standalone/build.gradle#L65

This PR will fix the misspelled property name which I used.

